### PR TITLE
Make sure truncated text ends with a newline character

### DIFF
--- a/src/sssom_validate_ui/app.py
+++ b/src/sssom_validate_ui/app.py
@@ -16,7 +16,7 @@ sys.tracebacklimit = 0
 def _maybe_prune_sssom_text(sssom_text, limit_lines_evaluated):
     sssom_length_within_limit = True
     if len(sssom_text.splitlines()) > limit_lines_evaluated:
-        truncated_text = "\n".join(sssom_text.splitlines()[:limit_lines_evaluated])
+        truncated_text = "\n".join(sssom_text.splitlines()[:limit_lines_evaluated]) + "\n"
         sssom_length_within_limit = False
     else:
         truncated_text = sssom_text


### PR DESCRIPTION
If the SSSOM text needs to be truncated because it contains more than 1,000 lines, the truncated text by default will not end with a newline character, which will make `tsvalid` unhappy. So we need to forcefully append a newline character after the truncation.